### PR TITLE
Modify CI config for new repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,9 @@ jobs:
       - run:
           name: Shellcheck
           command: |
-            find packages -name PKGBUILD -exec shellcheck '{}' +
-            find packages -name PKGTEST -exec shellcheck '{}' +
-            find buildpkg.sh ci-scripts dev-scripts misc-util -type f -exec shellcheck '{}' +
+            find . -name PKGBUILD -exec shellcheck '{}' +
+            find . -name PKGTEST -exec shellcheck '{}' +
+            find ci-scripts -type f -exec shellcheck '{}' +
   build-parallel:
     executor: build-machine
     steps:
@@ -63,14 +63,9 @@ jobs:
     steps:
       - add_ssh_keys
       - checkout
-      - restore_cache:
-          key: testing-repo-v4-
       - run:
           name: Upload package
           command: ./ci-scripts/ci-upload.sh
-      - save_cache:
-          key: testing-repo-v4-{{ checksum "pkgs/testing/testing.db.tar.gz" }}
-          paths: pkgs/testing
 
 workflows:
   version: 2

--- a/ci-scripts/ci-build.sh
+++ b/ci-scripts/ci-build.sh
@@ -4,7 +4,7 @@ bn="$(git rev-parse --abbrev-ref HEAD)"
 if [ "$bn" != 'main' ] ; then
     . "$CIRCLE_WORKING_DIRECTORY"/.env
     if [ -n "$pkg" ] && [ "$is_deleted" = 'false' ]; then
-        sudo MEREDIR="/tmp/.mere" -E ./buildpkg.sh "$pkg"
+        sudo MEREDIR="/tmp/mere" -E ./buildpkg.sh "$pkg"
     else
         printf 'No packages are required to build in this commit.\n'
     fi

--- a/ci-scripts/ci-build.sh
+++ b/ci-scripts/ci-build.sh
@@ -4,7 +4,50 @@ bn="$(git rev-parse --abbrev-ref HEAD)"
 if [ "$bn" != 'main' ] ; then
     . "$CIRCLE_WORKING_DIRECTORY"/.env
     if [ -n "$pkg" ] && [ "$is_deleted" = 'false' ]; then
-        sudo MEREDIR="/tmp/mere" -E ./buildpkg.sh "$pkg"
+
+        if printf '%s' "$bn" | grep -qE '^.*-parallel$'; then
+
+            DISTCC_PORT='40000'
+            DISTCC_CIDR='172.0.0.0/8'
+
+            curl -fsSL https://tailscale.com/install.sh | sudo sh
+            sudo tailscale up --authkey="$TS_KEY" \
+                --hostname="mereci-${CIRCLE_BUILD_NUM}-${CIRCLE_NODE_TOTAL}-${CIRCLE_NODE_INDEX}"
+
+            case "$CIRCLE_NODE_INDEX" in
+                0)
+                    DISTCC_HOSTS='localhost'
+                    step=1
+                    while [ "$step" -lt "$CIRCLE_NODE_TOTAL" ]; do
+                        peerip=$(dig +short "mereci-${CIRCLE_BUILD_NUM}-${CIRCLE_NODE_TOTAL}-${step}.bonobo-bluegill.ts.net")
+                        until [ -n "$peerip" ]; do
+                            sleep 5
+                            peerip=$(dig +short "mereci-${CIRCLE_BUILD_NUM}-${CIRCLE_NODE_TOTAL}-${step}.bonobo-bluegill.ts.net")
+                        done
+                        DISTCC_HOSTS="${DISTCC_HOSTS} ${peerip}:${DISTCC_PORT}"
+                        step=$((step + 1))
+                    done
+                    cat >.env <<-EOF
+					DISTCC_HOSTS=$DISTCC_HOSTS
+					CC=/usr/lib/distcc/cc
+					CXX=/usr/lib/distcc/c++
+					EOF
+                    MEREDIR="/tmp/mere" ./buildpkg.sh "$pkg"
+                    ;;
+                *)
+                    printf 'Listening on port %s\n' "$DISTCC_PORT"
+                    docker run -t --rm \
+                        -p "$DISTCC_PORT":"$DISTCC_PORT" -e DISTCC_PORT="$DISTCC_PORT" \
+                        -e DISTCC_CIDR="$DISTCC_CIDR" mere/distcc &
+                    # Listen on this port for any input to "signal" build job is finished
+                    printf 'Listening for done signal on port 40001\n'
+                    nc -l -p 40001
+                    ;;
+
+            esac
+        else
+            MEREDIR="/tmp/mere" ./buildpkg.sh "$pkg"
+        fi
     else
         printf 'No packages are required to build in this commit.\n'
     fi

--- a/ci-scripts/ci-build.sh
+++ b/ci-scripts/ci-build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 # shellcheck disable=SC2154,SC1090
 bn="$(git rev-parse --abbrev-ref HEAD)"
-if [ "$bn" != 'master' ] ; then
+if [ "$bn" != 'main' ] ; then
     . "$CIRCLE_WORKING_DIRECTORY"/.env
     if [ -n "$pkg" ] && [ "$is_deleted" = 'false' ]; then
         sudo MEREDIR="/tmp/.mere" ./buildpkg.sh "$pkg"

--- a/ci-scripts/ci-build.sh
+++ b/ci-scripts/ci-build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-# shellcheck disable=SC2154,SC1090
+# shellcheck disable=SC2154,SC1091
 bn="$(git rev-parse --abbrev-ref HEAD)"
 if [ "$bn" != 'main' ] ; then
     . "$CIRCLE_WORKING_DIRECTORY"/.env

--- a/ci-scripts/ci-build.sh
+++ b/ci-scripts/ci-build.sh
@@ -27,7 +27,7 @@ if [ "$bn" != 'main' ] ; then
                         DISTCC_HOSTS="${DISTCC_HOSTS} ${peerip}:${DISTCC_PORT}"
                         step=$((step + 1))
                     done
-                    cat >.env <<-EOF
+                    cat >.build-env <<-EOF
 					DISTCC_HOSTS=$DISTCC_HOSTS
 					CC=/usr/lib/distcc/cc
 					CXX=/usr/lib/distcc/c++

--- a/ci-scripts/ci-build.sh
+++ b/ci-scripts/ci-build.sh
@@ -4,7 +4,7 @@ bn="$(git rev-parse --abbrev-ref HEAD)"
 if [ "$bn" != 'main' ] ; then
     . "$CIRCLE_WORKING_DIRECTORY"/.env
     if [ -n "$pkg" ] && [ "$is_deleted" = 'false' ]; then
-        sudo MEREDIR="/tmp/.mere" ./buildpkg.sh "$pkg"
+        sudo MEREDIR="/tmp/.mere" -E ./buildpkg.sh "$pkg"
     else
         printf 'No packages are required to build in this commit.\n'
     fi

--- a/ci-scripts/ci-build.sh
+++ b/ci-scripts/ci-build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+# shellcheck disable=SC2154,SC1090
+bn="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$bn" != 'master' ] ; then
+    . "$CIRCLE_WORKING_DIRECTORY"/.env
+    if [ -n "$pkg" ] && [ "$is_deleted" = 'false' ]; then
+        sudo MEREDIR="/tmp/.mere" ./buildpkg.sh "$pkg"
+    else
+        printf 'No packages are required to build in this commit.\n'
+    fi
+fi

--- a/ci-scripts/ci-setup.sh
+++ b/ci-scripts/ci-setup.sh
@@ -24,3 +24,7 @@ cat >"$CIRCLE_WORKING_DIRECTORY"/.env <<EOF
 pkg='${unique_pkgs[0]}'
 is_deleted=$is_deleted
 EOF
+
+cat >"$CIRCLE_WORKING_DIRECTORY"/mere.key <<EOF
+$MERE_SIGNING_KEY
+EOF

--- a/ci-scripts/ci-setup.sh
+++ b/ci-scripts/ci-setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 pkgs=()
-for file in $(git diff --name-only HEAD~1) ; do
+for file in $(git diff --name-only main) ; do
     if printf '%s' "$file" | grep -q '^packages/.*/PKGBUILD'; then
         pkgs+=("${file%/*}")
     fi
@@ -25,6 +25,4 @@ pkg='${unique_pkgs[0]}'
 is_deleted=$is_deleted
 EOF
 
-cat >"$CIRCLE_WORKING_DIRECTORY"/mere.key <<EOF
-$MERE_SIGNING_KEY
-EOF
+printf '%s\n' "$MERE_SIGNING_KEY" | base64 -d >"$CIRCLE_WORKING_DIRECTORY"/mere.key

--- a/ci-scripts/ci-setup.sh
+++ b/ci-scripts/ci-setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+pkgs=()
+for file in $(git diff --name-only HEAD~1) ; do
+    if printf '%s' "$file" | grep -q '^packages/.*/PKGBUILD'; then
+        pkgs+=("${file%/*}")
+    fi
+done
+printf 'pkgs is: %s\n' "${pkgs[@]}"
+mapfile -t unique_pkgs < <(printf '%s\n' "${pkgs[@]}" | sort -u)
+if [ "${#unique_pkgs[@]}" -gt 1 ] ; then
+    printf 'More than one package directory has been changed in this commit.\n'
+    exit 1
+fi
+printf 'unique_pkgs is: %s\n' "${unique_pkgs[@]}"
+
+is_deleted='false'
+if git log --oneline --full-history -1 -p -- "${unique_pkgs[0]}/PKGBUILD" \
+    | head | grep -q '^+++ /dev/null'; then
+    is_deleted='true'
+fi
+
+install -d "$CIRCLE_WORKING_DIRECTORY"
+cat >"$CIRCLE_WORKING_DIRECTORY"/.env <<EOF
+pkg='${unique_pkgs[0]}'
+is_deleted=$is_deleted
+EOF

--- a/ci-scripts/ci-test.sh
+++ b/ci-scripts/ci-test.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -e
-# shellcheck disable=SC2154,SC1090
+# shellcheck disable=SC2154,SC1091
 . "$CIRCLE_WORKING_DIRECTORY"/.env
 if [ -n "$pkg" ] && [ -f "$pkg/PKGTEST" ]; then
   cd "$pkg"

--- a/ci-scripts/ci-test.sh
+++ b/ci-scripts/ci-test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -e
+# shellcheck disable=SC2154,SC1090
+. "$CIRCLE_WORKING_DIRECTORY"/.env
+if [ -n "$pkg" ] && [ -f "$pkg/PKGTEST" ]; then
+  cd "$pkg"
+  sh PKGTEST
+fi

--- a/ci-scripts/ci-upload.sh
+++ b/ci-scripts/ci-upload.sh
@@ -35,7 +35,7 @@ case "$bn" in
         find staging -name "*.pkg*" -not -name "*.sig" | while read -r file ; do
             mv -v "$file" pkgs/testing
             [ -f "${file}.sig" ] && mv -v "${file}.sig" pkgs/testing
-            ./usr/bin/repo-add -R pkgs/testing/testing.db.tar.gz "pkgs/testing/${file##*/}"
+            LIBRARY=./usr/share/makepkg ./usr/bin/repo-add -R pkgs/testing/testing.db.tar.gz "pkgs/testing/${file##*/}"
         done
         find staging -name "*.src.tar.xz" | while read -r file; do
             bn=${file##*/}

--- a/ci-scripts/ci-upload.sh
+++ b/ci-scripts/ci-upload.sh
@@ -19,7 +19,6 @@ case "$bn" in
         install -d ./var/lib/pacman
         sudo /tmp/pacman/usr/bin/pacman -Sy --config /tmp/pacman/etc/pacman.conf \
             -r . --noconfirm pacman-build
-        sudo sed -i '/bsdtar -xf .*dbfile/s@-C@--no-fflags -C@' bin/repo-add
 
         # Sync down existing files in the staging repo
         install -d pkgs/testing staging

--- a/ci-scripts/ci-upload.sh
+++ b/ci-scripts/ci-upload.sh
@@ -17,7 +17,7 @@ case "$bn" in
         tar -C /tmp/pacman -xf pacman-latest-x86_64.pkg.tar.xz 2>/dev/null
 
         install -d ./var/lib/pacman
-        sudo /tmp/pacman/bin/pacman -Sy --config /tmp/pacman/etc/pacman.conf \
+        sudo /tmp/pacman/usr/bin/pacman -Sy --config /tmp/pacman/etc/pacman.conf \
             -r . --noconfirm pacman-build
         sudo sed -i '/bsdtar -xf .*dbfile/s@-C@--no-fflags -C@' bin/repo-add
 

--- a/ci-scripts/ci-upload.sh
+++ b/ci-scripts/ci-upload.sh
@@ -35,7 +35,7 @@ case "$bn" in
         find staging -name "*.pkg*" -not -name "*.sig" | while read -r file ; do
             mv -v "$file" pkgs/testing
             [ -f "${file}.sig" ] && mv -v "${file}.sig" pkgs/testing
-            ./bin/repo-add -R pkgs/testing/testing.db.tar.gz "pkgs/testing/${file##*/}"
+            ./usr/bin/repo-add -R pkgs/testing/testing.db.tar.gz "pkgs/testing/${file##*/}"
         done
         find staging -name "*.src.tar.xz" | while read -r file; do
             bn=${file##*/}

--- a/ci-scripts/ci-upload.sh
+++ b/ci-scripts/ci-upload.sh
@@ -37,7 +37,14 @@ case "$bn" in
             mv -v "$file" pkgs/testing
             ./bin/repo-add -R pkgs/testing/testing.db.tar.gz "pkgs/testing/${file##*/}"
         done
-        find staging -name "*.src.tar.xz" -exec mv -v '{}' pkgs/testing/ \;
+        find staging -name "*.src.tar.xz" | while read -r file; do
+            bn=${file##*/}
+            noext=${bn%.src.tar.xz*}
+            norel=${noext%-*}
+            nover=${norel%-*}
+            find pkgs/testing -not -type d -name "${nover}*.src.tar.xz" -delete
+            mv -v "$file" pkgs/testing
+        done
 
         aws s3 sync --delete pkgs/testing/ s3://pkgs.merelinux.org/testing/
         aws s3 rm --recursive "s3://pkgs.merelinux.org/${prnum}/"

--- a/ci-scripts/ci-upload.sh
+++ b/ci-scripts/ci-upload.sh
@@ -33,8 +33,9 @@ case "$bn" in
             -o pkgs/testing/testing.files.tar.gz
 
         # Copy over the staging files to testing
-        find staging -name "*.pkg*" | while read -r file ; do
+        find staging -name "*.pkg*" -not -name "*.sig" | while read -r file ; do
             mv -v "$file" pkgs/testing
+            [ -f "${file}.sig" ] && mv -v "${file}.sig" pkgs/testing
             ./bin/repo-add -R pkgs/testing/testing.db.tar.gz "pkgs/testing/${file##*/}"
         done
         find staging -name "*.src.tar.xz" | while read -r file; do

--- a/ci-scripts/ci-upload.sh
+++ b/ci-scripts/ci-upload.sh
@@ -54,6 +54,7 @@ find staging -name "*.pkg*" -not -name "*.sig" | while read -r file ; do
     mv -v "$file" pkgs/testing
     [ -f "${file}.sig" ] && mv -v "${file}.sig" pkgs/testing
     LIBRARY=/tmp/tools/usr/share/makepkg repo-add \
+        --sign --key "${CIRCLE_WORKING_DIRECTORY}/mere.key" \
         -R pkgs/testing/testing.db.tar.gz "pkgs/testing/${file##*/}"
 done
 find staging -name "*.src.tar.xz" | while read -r file; do

--- a/ci-scripts/ci-upload.sh
+++ b/ci-scripts/ci-upload.sh
@@ -61,6 +61,7 @@ rsync -rlptv -e 'ssh -p 50220' \
     pkgsync@pkgs.merelinux.org::pkgs/testing/ pkgs/testing/
 
 # Copy over the staging files to testing
+printf '%s\n' "$MERE_SIGNING_KEY" | base64 -d >"$CIRCLE_WORKING_DIRECTORY"/mere.key
 find staging -name "*.pkg*" -not -name "*.sig" | while read -r file ; do
     mv -v "$file" pkgs/testing
     [ -f "${file}.sig" ] && mv -v "${file}.sig" pkgs/testing

--- a/ci-scripts/ci-upload.sh
+++ b/ci-scripts/ci-upload.sh
@@ -44,6 +44,7 @@ while [ "$i" -lt "$len" ]; do
 done
 
 # Sync down existing files in the testing repo
+printf 'Syncing down testing repo\n'
 install -d pkgs/testing
 rsync -rlptv \
     -e 'ssh pkgsync@pkgs.merelinux.org -p 50220 nc localhost 873' \
@@ -66,6 +67,7 @@ find staging -name "*.src.tar.xz" | while read -r file; do
 done
 
 # Upload
+printf 'Syncing up testing repo\n'
 rsync -rlptv --delete-after \
     -e 'ssh pkgsync@pkgs.merelinux.org -p 50220 nc localhost 873' \
     pkgs/testing/ pkgsync@pkgs.merelinux.org::pkgs/testing/

--- a/ci-scripts/ci-upload.sh
+++ b/ci-scripts/ci-upload.sh
@@ -19,8 +19,19 @@ fi
 
 # install pacman-build
 install -d /tmp/pacman
-curl -LO http://pkgs.merelinux.org/testing/pacman-latest-x86_64.pkg.tar.xz
+curl -LO http://pkgs.merelinux.org/core/pacman-latest-x86_64.pkg.tar.xz
 tar -C /tmp/pacman -xf pacman-latest-x86_64.pkg.tar.xz 2>/dev/null
+
+cat >/tmp/pacman/etc/pacman.conf <<EOF
+[options]
+HoldPkg      = pacman busybox
+Architecture = auto
+ParallelDownloads = 3
+SigLevel = Never
+
+[testing]
+Server = https://pkgs.merelinux.org/testing
+EOF
 
 install -d /tmp/tools/var/lib/pacman
 sudo /tmp/pacman/usr/bin/pacman -Sy --config /tmp/pacman/etc/pacman.conf \

--- a/ci-scripts/ci-upload.sh
+++ b/ci-scripts/ci-upload.sh
@@ -27,15 +27,15 @@ case "$bn" in
         aws s3 sync "s3://pkgs.merelinux.org/${prnum}/" staging/
 
         # Grab the testing dbs
-        curl -fsL http://pkgs.merelinux.org/testing/main.db.tar.gz \
-            -o pkgs/testing/main.db.tar.gz
-        curl -fsL http://pkgs.merelinux.org/testing/main.files.tar.gz \
-            -o pkgs/testing/main.files.tar.gz
+        curl -fsL http://pkgs.merelinux.org/testing/testing.db.tar.gz \
+            -o pkgs/testing/testing.db.tar.gz
+        curl -fsL http://pkgs.merelinux.org/testing/testing.files.tar.gz \
+            -o pkgs/testing/testing.files.tar.gz
 
         # Copy over the staging files to testing
         find staging -name "*.pkg*" | while read -r file ; do
             mv -v "$file" pkgs/testing
-            ./bin/repo-add -R pkgs/testing/main.db.tar.gz "pkgs/testing/${file##*/}"
+            ./bin/repo-add -R pkgs/testing/testing.db.tar.gz "pkgs/testing/${file##*/}"
         done
         find staging -name "*.src.tar.xz" -exec mv -v '{}' pkgs/testing/ \;
 

--- a/ci-scripts/ci-upload.sh
+++ b/ci-scripts/ci-upload.sh
@@ -46,8 +46,7 @@ done
 # Sync down existing files in the testing repo
 printf 'Syncing down testing repo\n'
 install -d pkgs/testing
-rsync -rlptv \
-    -e 'ssh pkgsync@pkgs.merelinux.org -p 50220 nc localhost 873' \
+rsync -rlptv -e 'ssh -p 50220' \
     pkgsync@pkgs.merelinux.org::pkgs/testing/ pkgs/testing/
 
 # Copy over the staging files to testing
@@ -66,13 +65,11 @@ find staging -name "*.src.tar.xz" | while read -r file; do
     mv -v "$file" "src/${nover}/"
 
     printf 'Syncing up source packages\n'
-    rsync -rlptv --delete-after \
-        -e 'ssh pkgsync@pkgs.merelinux.org -p 50220 nc localhost 873' \
+    rsync -rlptv --delete-after -e 'ssh -p 50220' \
         "src/${nover}/" "pkgsync@pkgs.merelinux.org::pkgs/src/${nover}/"
 done
 
 # Upload
 printf 'Syncing up testing repo\n'
-rsync -rlptv --delete-after \
-    -e 'ssh pkgsync@pkgs.merelinux.org -p 50220 nc localhost 873' \
+rsync -rlptv --delete-after -e 'ssh -p 50220' \
     pkgs/testing/ pkgsync@pkgs.merelinux.org::pkgs/testing/

--- a/ci-scripts/ci-upload.sh
+++ b/ci-scripts/ci-upload.sh
@@ -3,7 +3,7 @@ sudo pip install awscli
 
 bn="$(git rev-parse --abbrev-ref HEAD)"
 case "$bn" in
-    master)
+    main)
         prnum=$(git log --oneline -1 | grep -o 'Merge pull request.*from' | \
                 cut -d' ' -f4 | sed 's@#@@')
         if ! printf '%d' "$prnum" >/dev/null 2>&1 ; then

--- a/ci-scripts/ci-upload.sh
+++ b/ci-scripts/ci-upload.sh
@@ -62,8 +62,13 @@ find staging -name "*.src.tar.xz" | while read -r file; do
     noext=${bn%.src.tar.xz*}
     norel=${noext%-*}
     nover=${norel%-*}
-    find pkgs/testing -not -type d -name "${nover}*.src.tar.xz" -delete
-    mv -v "$file" pkgs/testing
+    install -d "src/${nover}"
+    mv -v "$file" "src/${nover}/"
+
+    printf 'Syncing up source packages\n'
+    rsync -rlptv --delete-after \
+        -e 'ssh pkgsync@pkgs.merelinux.org -p 50220 nc localhost 873' \
+        "src/${nover}/" "pkgsync@pkgs.merelinux.org::pkgs/src/${nover}/"
 done
 
 # Upload

--- a/ci-scripts/ci-upload.sh
+++ b/ci-scripts/ci-upload.sh
@@ -19,7 +19,7 @@ fi
 
 # install pacman-build
 install -d /tmp/pacman
-curl -LO http://pkgs.merelinux.org/stable/pacman-latest-x86_64.pkg.tar.xz
+curl -LO http://pkgs.merelinux.org/testing/pacman-latest-x86_64.pkg.tar.xz
 tar -C /tmp/pacman -xf pacman-latest-x86_64.pkg.tar.xz 2>/dev/null
 
 install -d /tmp/tools/var/lib/pacman

--- a/ci-scripts/ci-upload.sh
+++ b/ci-scripts/ci-upload.sh
@@ -1,0 +1,58 @@
+#!/bin/bash -xe
+sudo pip install awscli
+
+bn="$(git rev-parse --abbrev-ref HEAD)"
+case "$bn" in
+    master)
+        prnum=$(git log --oneline -1 | grep -o 'Merge pull request.*from' | \
+                cut -d' ' -f4 | sed 's@#@@')
+        if ! printf '%d' "$prnum" >/dev/null 2>&1 ; then
+            printf 'Cannot determine an upload path for the merged PR\n'
+            exit 1
+        fi
+
+        # install pacman-build
+        install -d /tmp/pacman
+        curl -LO http://pkgs.merelinux.org/stable/pacman-latest-x86_64.pkg.tar.xz
+        tar -C /tmp/pacman -xf pacman-latest-x86_64.pkg.tar.xz 2>/dev/null
+
+        install -d ./var/lib/pacman
+        sudo /tmp/pacman/bin/pacman -Sy --config /tmp/pacman/etc/pacman.conf \
+            -r . --noconfirm pacman-build
+        sudo sed -i '/bsdtar -xf .*dbfile/s@-C@--no-fflags -C@' bin/repo-add
+
+        # Sync down existing files in the staging repo
+        install -d pkgs/testing staging
+        aws s3 sync s3://pkgs.merelinux.org/testing/ pkgs/testing/
+        aws s3 sync "s3://pkgs.merelinux.org/${prnum}/" staging/
+
+        # Grab the testing dbs
+        curl -fsL http://pkgs.merelinux.org/testing/main.db.tar.gz \
+            -o pkgs/testing/main.db.tar.gz
+        curl -fsL http://pkgs.merelinux.org/testing/main.files.tar.gz \
+            -o pkgs/testing/main.files.tar.gz
+
+        # Copy over the staging files to testing
+        find staging -name "*.pkg*" | while read -r file ; do
+            mv -v "$file" pkgs/testing
+            ./bin/repo-add -R pkgs/testing/main.db.tar.gz "pkgs/testing/${file##*/}"
+        done
+        find staging -name "*.src.tar.xz" -exec mv -v '{}' pkgs/testing/ \;
+
+        aws s3 sync --delete pkgs/testing/ s3://pkgs.merelinux.org/testing/
+        aws s3 rm --recursive "s3://pkgs.merelinux.org/${prnum}/"
+        ;;
+    *)
+        prnum=$(printf '%s' "$CIRCLE_PULL_REQUEST" | awk -F/ '{print $NF}')
+        if [ -z "$prnum" ] || ! printf '%d' "$prnum" >/dev/null 2>&1 ; then
+            printf 'Cannot determine an upload path for the merged PR\n'
+            exit 1
+        fi
+
+        install -d "pkgs/${prnum}"
+        if [ -d "/tmp/.mere/pkgs" ] ; then
+            sudo find "/tmp/.mere/pkgs" -type f -exec mv -v '{}' "pkgs/${prnum}/" \;
+            aws s3 sync pkgs s3://pkgs.merelinux.org
+        fi
+        ;;
+esac


### PR DESCRIPTION
- Instead of having a 'packages' directory, will keep those directories in the root
- Will only have ci-scripts for now, get rid of other scripts. Those will also eventually be moved to a package for re-usability.
- Remove circle-ci caching for simplicity for now