### PR TITLE
Add additional rationale notes for distcc

### DIFF
--- a/packages/distcc/PKGBUILD
+++ b/packages/distcc/PKGBUILD
@@ -1,7 +1,9 @@
 #!/bin/bash
 # shellcheck disable=SC2034,SC2154,SC2068
 
-# Rationale: Greatly improves build times in CI pipelines for some packages
+# Rationale: Greatly improves build times in CI pipelines for some packages.
+# This is necessary to support fully automated builds with the current CI
+# architecture.
 
 pkgname=distcc
 pkgver=3.4


### PR DESCRIPTION
Also serves to bump it to trigger a new build and publish. There still seems to be a gap in building/pushing. May need to just build on merges as well.