### PR TITLE
CI fixes

### DIFF
--- a/ci-scripts/ci-build.sh
+++ b/ci-scripts/ci-build.sh
@@ -8,10 +8,6 @@ case "$bn" in
         DISTCC_PORT='40000'
         DISTCC_CIDR='172.0.0.0/8'
 
-        curl -fsSL https://tailscale.com/install.sh | sudo sh
-        sudo tailscale up --authkey="$TS_KEY" \
-            --hostname="mereci-${CIRCLE_BUILD_NUM}-${CIRCLE_NODE_TOTAL}-${CIRCLE_NODE_INDEX}"
-
         case "$CIRCLE_NODE_INDEX" in
             0)
                 DISTCC_HOSTS='localhost'


### PR DESCRIPTION
- Move the tailscale setup back to ci-setup. Needs to be in place early to allow the cleanup to succeed
- Setup pacman on the hosts to allow for querying the sync repo