### PR TITLE
Fix main pipeline bug

### DIFF
--- a/ci-scripts/ci-setup.sh
+++ b/ci-scripts/ci-setup.sh
@@ -31,7 +31,7 @@ if [ "$bn" = 'main' ] ; then
                       -r /tmp/tools -Si "$pkg" | \
                       grep -E '^Version' | awk '{print $NF}')
             if [ "$syncver" != "${pkgver}-${pkgrel}" ]; then
-                pkgs+=("${dir%/*}")
+                pkgs+=("$dir")
                 break
             fi
         done


### PR DESCRIPTION
The "dir" variable was already the name of the package directory and didn't need a dirname split applied