### PR TITLE
distcc: Remove libtool/autotools dependency

### DIFF
--- a/packages/distcc/ChangeLog
+++ b/packages/distcc/ChangeLog
@@ -1,3 +1,7 @@
+3.4-2 (2023-02-28)
+
+	Remove libtool/autotools dependency
+
 3.4-1 (2023-01-22)
 
 	Initial version

--- a/packages/distcc/PKGBUILD
+++ b/packages/distcc/PKGBUILD
@@ -7,7 +7,7 @@
 
 pkgname=distcc
 pkgver=3.4
-pkgrel=1
+pkgrel=2
 pkgdesc='A fast, free distributed C/C++ compiler'
 arch=(x86_64)
 url='https://www.distcc.org'
@@ -16,8 +16,6 @@ groups=()
 depends=(python)
 makedepends=(
     libiberty-dev
-    libtool
-    m4
     python-dev
 )
 options=()
@@ -39,7 +37,6 @@ build() {
         -e '/void dcc_stats_init_kid/s@()@(void)@' src/stats.c
     sed -i "/Python.h/s@.*@#define PY_SSIZE_T_CLEAN\n&@" \
         include_server/c_extensions/distcc_pump_c_extensions_module.c
-    ./autogen.sh
     ./configure --prefix=/usr \
         --host="$CHOST" \
         --build="$CHOST"


### PR DESCRIPTION
distcc can build find without running autogen.sh. Removing this dep may mean that auto* may possibly be skipped in core