### PR TITLE
zlib-ng: Add to core repo at 2.0.6

### DIFF
--- a/packages/zlib-ng/ChangeLog
+++ b/packages/zlib-ng/ChangeLog
@@ -1,0 +1,9 @@
+2.0.6-2 (2023-03-03)
+
+	Bump the release version so that a new package will be built and signed 
+	with the new signature
+
+2.0.6-1 (2022-09-25)
+
+	Initial version
+

--- a/packages/zlib-ng/PKGBUILD
+++ b/packages/zlib-ng/PKGBUILD
@@ -1,0 +1,65 @@
+#!/bin/bash
+# shellcheck disable=SC2034,SC2154,SC2068
+
+pkgname=(zlib-ng zlib-ng-dev)
+pkgver=2.0.6
+pkgrel=2
+pkgdesc='zlib replacement with optimizations for "next generation" systems.'
+arch=(x86_64)
+url='https://github.com/zlib-ng/zlib-ng'
+license=(zlib)
+groups=()
+depends=()
+makedepends=(cmake)
+options=()
+changelog=ChangeLog
+source=(
+    "https://github.com/zlib-ng/zlib-ng/archive/refs/tags/${pkgver}.tar.gz"
+)
+sha256sums=(
+    8258b75a72303b661a238047cb348203d88d9dddf85d480ed885f375916fcab6
+)
+
+
+build() {
+    cd_unpacked_src
+    mkdir build
+    cd build || return 1
+    cmake \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DZLIB_COMPAT=ON \
+        ..
+    make
+}
+
+package_zlib-ng() {
+    pkgfiles=(
+        usr/lib/lib*.so.*
+    )
+    depends=(
+        "ld-musl-$(arch).so.1"
+    )
+    provides=(
+        libz.so.1
+    )
+    replaces=(zlib)
+    cd_unpacked_src
+    cd build || return 1
+    make DESTDIR="${pkgdirbase}/dest" install
+    std_split_package
+}
+
+package_zlib-ng-dev() {
+    pkgfiles=(
+        usr/include
+        usr/lib/lib*.a
+        usr/lib/lib*.so
+        usr/lib/pkgconfig
+    )
+    depends=(
+        "zlib-ng=${pkgver}"
+    )
+    replaces=(zlib-dev)
+    std_split_package
+}


### PR DESCRIPTION
No change from previous version, just bump the release so that a new package will be built and signed