### PR TITLE
pacman: Improve file detection in file.sh

### DIFF
--- a/packages/pacman/ChangeLog
+++ b/packages/pacman/ChangeLog
@@ -1,3 +1,7 @@
+6.0.1-6 (2023-03-05)
+
+	Modify file.sh to better match detected file types
+
 6.0.1-5 (2023-03-02)
 
 	Improve the dotfiles check. Use find instead of shell globbing

--- a/packages/pacman/PKGBUILD
+++ b/packages/pacman/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=(pacman pacman-build)
 pkgver=6.0.1
-pkgrel=5
+pkgrel=6
 pkgdesc='A lightweight Package Manager'
 arch=(x86_64)
 url='https://www.archlinux.org/pacman/'
@@ -38,6 +38,7 @@ source=(
     makepkg.conf
     pacman.conf
     fakeroot
+    file.sh
     dependencies.sh
     dotfiles.sh
     zz-dedup.sh
@@ -54,6 +55,7 @@ sha256sums=(
     c58ece17155f655c320509979e0116e93ac9b515dd8b1c9cd7966bbf33accfe5
     2cc0b229f9ceb0a7df51237e99fb52410332694a6b0194ef018dbce3258a242f
     689b6064bea140990b6655cba26bc8cb16d1590c090688d169e5c3929d12a1e3
+    de0ab64af214ebba5e0f4abd9e235a423b52d9fc90b38b6b321686fe13d9f777
     57345d168a3332a0a07e63e13003d1fb351ca66329283addad23070f7bfdbe59
     4b047a3ce6b9be3e3af4c8641d52446055ce559d935a4eff3918be8783510f7a
     4bd067e3bdfe37ff8f028d8d71685206f8791b0a6f9737a0875e6ddab3394be6
@@ -100,6 +102,7 @@ package_pacman() {
     install -m 0644 "${srcdir}/pacman.conf" etc/
     install -m 0644 "${srcdir}/makepkg.conf" etc/
     install -m 0755 "${srcdir}/fakeroot" usr/bin/
+    install -m 0755 "${srcdir}/file.sh" usr/share/makepkg/source/
     install -m 0755 "${srcdir}/dependencies.sh" usr/share/makepkg/lint_package/
     # Replace the upstream dotfiles check with a less fragile one that doesn't depend on globs
     install -m 0755 "${srcdir}/dotfiles.sh" usr/share/makepkg/lint_package/

--- a/packages/pacman/file.sh
+++ b/packages/pacman/file.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+#
+#   file.sh - function for handling the download and extraction of source files
+#
+#   Copyright (c) 2015-2021 Pacman Development Team <pacman-dev@archlinux.org>
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+[[ -n "$LIBMAKEPKG_SOURCE_FILE_SH" ]] && return
+LIBMAKEPKG_SOURCE_FILE_SH=1
+
+
+LIBRARY=${LIBRARY:-'/usr/share/makepkg'}
+
+source "$LIBRARY/util/message.sh"
+source "$LIBRARY/util/pkgbuild.sh"
+
+
+download_file() {
+	local netfile=$1
+
+	local filepath=$(get_filepath "$netfile")
+	if [[ -n "$filepath" ]]; then
+		msg2 "$(gettext "Found %s")" "${filepath##*/}"
+		return
+	fi
+
+	local proto=$(get_protocol "$netfile")
+
+	# find the client we should use for this URL
+	local -a cmdline
+	IFS=' ' read -a cmdline < <(get_downloadclient "$proto")
+	wait $! || exit
+
+	local filename=$(get_filename "$netfile")
+	local url=$(get_url "$netfile")
+
+	if [[ $proto = "scp" ]]; then
+		# scp downloads should not pass the protocol in the url
+		url="${url##*://}"
+	fi
+
+	msg2 "$(gettext "Downloading %s...")" "$filename"
+
+	# temporary download file, default to last component of the URL
+	local dlfile="${url##*/}"
+
+	# replace %o by the temporary dlfile if it exists
+	if [[ ${cmdline[*]} = *%o* ]]; then
+		dlfile=$filename.part
+		cmdline=("${cmdline[@]//%o/$dlfile}")
+	fi
+	# add the URL, either in place of %u or at the end
+	if [[ ${cmdline[*]} = *%u* ]]; then
+		cmdline=("${cmdline[@]//%u/$url}")
+	else
+		cmdline+=("$url")
+	fi
+
+	if ! command -- "${cmdline[@]}" >&2; then
+		[[ ! -s $dlfile ]] && rm -f -- "$dlfile"
+		error "$(gettext "Failure while downloading %s")" "$url"
+		plainerr "$(gettext "Aborting...")"
+		exit 1
+	fi
+
+	# rename the temporary download file to the final destination
+	if [[ $dlfile != "$filename" ]]; then
+		mv -f "$SRCDEST/$dlfile" "$SRCDEST/$filename"
+	fi
+}
+
+extract_file() {
+	local netfile=$1
+
+	local file=$(get_filename "$netfile")
+	local filepath=$(get_filepath "$file")
+	rm -f "$srcdir/${file}"
+	ln -s "$filepath" "$srcdir/"
+
+	if in_array "$file" "${noextract[@]}"; then
+		# skip source files in the noextract=() array
+		# these are marked explicitly to NOT be extracted
+		return 0
+	fi
+
+	# do not rely on extension for file type
+	local file_type=$(file -S -bizL -- "$file")
+	local ext=${file##*.}
+	local cmd=''
+	case "$file_type" in
+		application/x-tar*|application/zip*|application/x-zip*|application/x-cpio*)
+			cmd="bsdtar"
+            return ;;
+		application/x-gzip*|*application/gzip*)
+			case "$ext" in
+				gz|z|Z) cmd="gzip" ;;
+				*) return;;
+			esac ;;
+		application/x-bzip*)
+			case "$ext" in
+				bz2|bz) cmd="bzip2" ;;
+				*) return;;
+			esac ;;
+		application/x-xz*)
+			case "$ext" in
+				xz) cmd="xz" ;;
+				*) return;;
+			esac ;;
+		application/zstd*)
+			case "$ext" in
+				zst) cmd="zstd" ;;
+				*) return;;
+			esac ;;
+		*)
+			# See if bsdtar can recognize the file
+			if bsdtar -tf "$file" -q '*' &>/dev/null; then
+				cmd="bsdtar"
+			else
+				return 0
+			fi ;;
+	esac
+
+	local ret=0
+	msg2 "$(gettext "Extracting %s with %s")" "$file" "$cmd"
+	if [[ $cmd = "bsdtar" ]]; then
+		$cmd -xf "$file" || ret=$?
+	else
+		rm -f -- "${file%.*}"
+		$cmd -dcf -- "$file" > "${file%.*}" || ret=$?
+	fi
+	if (( ret )); then
+		error "$(gettext "Failed to extract %s")" "$file"
+		plainerr "$(gettext "Aborting...")"
+		exit 1
+	fi
+
+	if (( EUID == 0 )); then
+		# change perms of all source files to root user & root group
+		chown -R 0:0 "$srcdir"
+	fi
+}


### PR DESCRIPTION
- Exit the detection case early if the file type detected is tar
- Only match the description at the beggining of the line, instead of potential matches later