### PR TITLE
libarchive: Remove dep on iconv

### DIFF
--- a/packages/libarchive/ChangeLog
+++ b/packages/libarchive/ChangeLog
@@ -1,3 +1,7 @@
+3.6.2-2 (2023-03-05)
+
+	Remove explicit dependency on iconv in pkgconfig file for now
+
 3.6.2-1 (2023-03-03)
 
 	Upgrade to 3.6.2

--- a/packages/libarchive/PKGBUILD
+++ b/packages/libarchive/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=(
     libarchive-dev
 )
 pkgver=3.6.2
-pkgrel=1
+pkgrel=2
 pkgdesc='Multi-format archive and compression library'
 arch=(x86_64)
 url='http://www.libarchive.org'
@@ -65,4 +65,5 @@ package_libarchive-dev() {
     )
     depends=(libarchive)
     std_split_package
+    sed -i 's@iconv@@' "${pkgdir}/usr/lib/pkgconfig/libarchive.pc"
 }


### PR DESCRIPTION
The installed pkconfig file lists a dependency on iconv that is not necessarily required