### PR TITLE
[pacman] Change config of target triplet

### DIFF
--- a/packages/pacman/ChangeLog
+++ b/packages/pacman/ChangeLog
@@ -1,3 +1,7 @@
+6.0.1-9 (2023-12-17)
+
+	Change default target triplet. Switch from 'pc' to 'unknown'.
+
 6.0.1-8 (2023-03-06)
 
 	Bug fix for file.sh. Don't attempt to extract all files.

--- a/packages/pacman/PKGBUILD
+++ b/packages/pacman/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=(pacman pacman-build)
 pkgver=6.0.1
-pkgrel=8
+pkgrel=9
 pkgdesc='A lightweight Package Manager'
 arch=(x86_64)
 url='https://www.archlinux.org/pacman/'
@@ -68,7 +68,7 @@ sha256sums=(
     a60fa831cf70cb6ead014bd1c220cafce9335dff340ed72039e24b8c9fac2617
     b2aa11175af7962e99618f61c9071f6bce2dda752811252cad35d92bd74cedbd
     4bf69ed432ecc1a6517cce9ccf79a54133ca2a6bc4c74f53807ae18248a5c14c
-    c58ece17155f655c320509979e0116e93ac9b515dd8b1c9cd7966bbf33accfe5
+    e843505330f11bdbd7a5f81c43daf2ab99a76c1941a2236cd02e13c985af087e
     2cc0b229f9ceb0a7df51237e99fb52410332694a6b0194ef018dbce3258a242f
     689b6064bea140990b6655cba26bc8cb16d1590c090688d169e5c3929d12a1e3
     6af18921b77236b530b7b6b5d266e7c410cb9b961d68d3bd89108d6f0299ff02

--- a/packages/pacman/makepkg.conf
+++ b/packages/pacman/makepkg.conf
@@ -5,7 +5,7 @@ DLAGENTS=('ftp::/usr/bin/curl -qfC - --ftp-pasv --retry 3 --retry-delay 3 -o %o 
 VCSCLIENTS=('git::git')
 
 CARCH="$(arch)"
-CHOST="$(arch)-pc-linux-musl"
+CHOST="$(arch)-unknown-linux-musl"
 
 CFLAGS="-Os -pipe -fno-asynchronous-unwind-tables -Werror-implicit-function-declaration"
 CXXFLAGS="$CFLAGS"


### PR DESCRIPTION
Change from [arch]-pc-linux-musl to [arch]-unknown-linux-musl

This will match more closely some expectations of certain systems, notably the Rust build system.