### PR TITLE
Remove parallel builds for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,23 +62,13 @@ workflows:
   version: 2
   parallel:
     when:
-      or:
-        - matches:
-            pattern: "^.*-parallel$"
-            value: << pipeline.git.branch >>
-        - equal: [ main, << pipeline.git.branch >> ]
+      matches:
+        pattern: "^.*-parallel$"
+        value: << pipeline.git.branch >>
     jobs:
       - lint
       - build-parallel
   single:
-    when:
-      and:
-        - not:
-            matches:
-              pattern: "^.*-parallel$"
-              value: << pipeline.git.branch >>
-        - not:
-            equal: [ main, << pipeline.git.branch >> ]
     jobs:
       - lint
       - build


### PR DESCRIPTION
It looks like something is breaking with distcc. For now just return to single builds which are fine for most use cases and will investigate parallel as needed with future builds.