### PR TITLE
[pacman] Remove custom file.sh

### DIFF
--- a/packages/pacman/ChangeLog
+++ b/packages/pacman/ChangeLog
@@ -1,3 +1,7 @@
+6.0.1-10 (2024-02-26)
+
+	Remove custom file.sh
+
 6.0.1-9 (2023-12-17)
 
 	Change default target triplet. Switch from 'pc' to 'unknown'.

--- a/packages/pacman/PKGBUILD
+++ b/packages/pacman/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=(pacman pacman-build)
 pkgver=6.0.1
-pkgrel=9
+pkgrel=10
 pkgdesc='A lightweight Package Manager'
 arch=(x86_64)
 url='https://www.archlinux.org/pacman/'
@@ -38,7 +38,6 @@ source=(
     makepkg.conf
     pacman.conf
     fakeroot
-    file.sh
     dependencies.sh
     dotfiles.sh
     zz-dedup.sh
@@ -54,7 +53,6 @@ noextract=(
     makepkg.conf
     pacman.conf
     fakeroot
-    file.sh
     dependencies.sh
     dotfiles.sh
     zz-dedup.sh
@@ -71,7 +69,6 @@ sha256sums=(
     e843505330f11bdbd7a5f81c43daf2ab99a76c1941a2236cd02e13c985af087e
     2cc0b229f9ceb0a7df51237e99fb52410332694a6b0194ef018dbce3258a242f
     689b6064bea140990b6655cba26bc8cb16d1590c090688d169e5c3929d12a1e3
-    6af18921b77236b530b7b6b5d266e7c410cb9b961d68d3bd89108d6f0299ff02
     57345d168a3332a0a07e63e13003d1fb351ca66329283addad23070f7bfdbe59
     4b047a3ce6b9be3e3af4c8641d52446055ce559d935a4eff3918be8783510f7a
     4bd067e3bdfe37ff8f028d8d71685206f8791b0a6f9737a0875e6ddab3394be6
@@ -79,7 +76,6 @@ sha256sums=(
 )
 
 build() {
-    # Bypass broken file.sh for now, can remove later
     cd "${srcdir}" || return 1
     tar -xf pacman-${pkgver}.tar.xz
     cd_unpacked_src
@@ -121,7 +117,6 @@ package_pacman() {
     install -m 0644 "${srcdir}/pacman.conf" etc/
     install -m 0644 "${srcdir}/makepkg.conf" etc/
     install -m 0755 "${srcdir}/fakeroot" usr/bin/
-    install -m 0755 "${srcdir}/file.sh" usr/share/makepkg/source/
     install -m 0755 "${srcdir}/dependencies.sh" usr/share/makepkg/lint_package/
     # Replace the upstream dotfiles check with a less fragile one that doesn't depend on globs
     install -m 0755 "${srcdir}/dotfiles.sh" usr/share/makepkg/lint_package/


### PR DESCRIPTION
There was a forked version of makepkg's file.sh which missed some upstream fixes. Remove for now.