### PR TITLE
Don't require signatures on buildlocal db

### DIFF
--- a/packages/pacman/pacman-dev.conf
+++ b/packages/pacman/pacman-dev.conf
@@ -9,6 +9,7 @@ SigLevel = Required
 
 [buildlocal]
 Server = file:///mere/pkgs
+SigLevel = Never
 
 [core]
 Server = https://pkgs.merelinux.org/core/testing/os/$arch


### PR DESCRIPTION
This avoids for now having to set up an intial, signed db when doing local development or in the container. However the build process will still sign packages and the db which can be verified before using any additional packages in a test env.